### PR TITLE
Move knockout dependency to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "bugs": {
     "url": "https://github.com/derekpeterson/knockout.mapping/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "knockout": "^3.1.0"
+  },
+  "devDependencies": {
     "knockout": "^3.1.0"
   }
 }


### PR DESCRIPTION
Fixes including duplicate copies of knockout when using browserify to bundle javascript.

Without this change installing `knockout@3.0.0` and `knockout.mapping@2.4.3` works fine and results in 2 copies of knockout being included in the resulting bundle, not what you really want. With this change npm will give an `unmet dependency` warning if the installed version of knockout doesn't satisfy the peer dependency constraint.