### PR TITLE
Make Knockout a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/derekpeterson/knockout.mapping/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "knockout": "^3.1.0"
   }
 }


### PR DESCRIPTION
This avoids the risk of unintentionally loading two copies of Knockout.